### PR TITLE
remove mumlibs dependency on rust-mumble-protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,7 +842,6 @@ dependencies = [
  "colored",
  "fern",
  "log",
- "mumble-protocol",
  "serde",
  "toml",
 ]

--- a/mumd/src/state.rs
+++ b/mumd/src/state.rs
@@ -16,7 +16,7 @@ use mumble_protocol::voice::Serverbound;
 use mumlib::command::{Command, CommandResponse};
 use mumlib::config::Config;
 use mumlib::error::{ChannelIdentifierError, Error};
-use mumlib::state::UserDiff;
+use crate::state::user::UserDiff;
 use std::net::{SocketAddr, ToSocketAddrs};
 use tokio::sync::{mpsc, watch};
 

--- a/mumd/src/state/user.rs
+++ b/mumd/src/state/user.rs
@@ -78,7 +78,7 @@ impl User {
         }
     }
 
-    pub fn apply_user_diff(&mut self, diff: &mumlib::state::UserDiff) {
+    pub fn apply_user_diff(&mut self, diff: &crate::state::user::UserDiff) {
         if let Some(comment) = diff.comment.clone() {
             self.comment = Some(comment);
         }
@@ -153,5 +153,68 @@ impl From<&User> for mumlib::state::User {
             mute: user.mute,
             deaf: user.deaf,
         }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct UserDiff {
+    pub comment: Option<String>,
+    pub hash: Option<String>,
+    pub name: Option<String>,
+    pub priority_speaker: Option<bool>,
+    pub recording: Option<bool>,
+
+    pub suppress: Option<bool>,  // by me
+    pub self_mute: Option<bool>, // by self
+    pub self_deaf: Option<bool>, // by self
+    pub mute: Option<bool>,      // by admin
+    pub deaf: Option<bool>,      // by admin
+
+    pub channel_id: Option<u32>,
+}
+
+impl UserDiff {
+    pub fn new() -> Self {
+        UserDiff::default()
+    }
+}
+
+impl From<msgs::UserState> for UserDiff {
+    fn from(mut msg: msgs::UserState) -> Self {
+        let mut ud = UserDiff::new();
+        if msg.has_comment() {
+            ud.comment = Some(msg.take_comment());
+        }
+        if msg.has_hash() {
+            ud.hash = Some(msg.take_hash());
+        }
+        if msg.has_name() {
+            ud.name = Some(msg.take_name());
+        }
+        if msg.has_priority_speaker() {
+            ud.priority_speaker = Some(msg.get_priority_speaker());
+        }
+        if msg.has_recording() {
+            ud.recording = Some(msg.get_recording());
+        }
+        if msg.has_suppress() {
+            ud.suppress = Some(msg.get_suppress());
+        }
+        if msg.has_self_mute() {
+            ud.self_mute = Some(msg.get_self_mute());
+        }
+        if msg.has_self_deaf() {
+            ud.self_deaf = Some(msg.get_self_deaf());
+        }
+        if msg.has_mute() {
+            ud.mute = Some(msg.get_mute());
+        }
+        if msg.has_deaf() {
+            ud.deaf = Some(msg.get_deaf());
+        }
+        if msg.has_channel_id() {
+            ud.channel_id = Some(msg.get_channel_id());
+        }
+        ud
     }
 }

--- a/mumlib/Cargo.toml
+++ b/mumlib/Cargo.toml
@@ -11,6 +11,5 @@ edition = "2018"
 colored = "2.0"
 fern = "0.5"
 log = "0.4"
-mumble-protocol = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.5"

--- a/mumlib/src/state.rs
+++ b/mumlib/src/state.rs
@@ -1,4 +1,3 @@
-use mumble_protocol::control::msgs;
 use serde::export::Formatter;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -152,68 +151,5 @@ impl Display for User {
             true_to_str!(self.mute, "m"),
             true_to_str!(self.deaf, "d")
         )
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct UserDiff {
-    pub comment: Option<String>,
-    pub hash: Option<String>,
-    pub name: Option<String>,
-    pub priority_speaker: Option<bool>,
-    pub recording: Option<bool>,
-
-    pub suppress: Option<bool>,  // by me
-    pub self_mute: Option<bool>, // by self
-    pub self_deaf: Option<bool>, // by self
-    pub mute: Option<bool>,      // by admin
-    pub deaf: Option<bool>,      // by admin
-
-    pub channel_id: Option<u32>,
-}
-
-impl UserDiff {
-    pub fn new() -> Self {
-        UserDiff::default()
-    }
-}
-
-impl From<msgs::UserState> for UserDiff {
-    fn from(mut msg: msgs::UserState) -> Self {
-        let mut ud = UserDiff::new();
-        if msg.has_comment() {
-            ud.comment = Some(msg.take_comment());
-        }
-        if msg.has_hash() {
-            ud.hash = Some(msg.take_hash());
-        }
-        if msg.has_name() {
-            ud.name = Some(msg.take_name());
-        }
-        if msg.has_priority_speaker() {
-            ud.priority_speaker = Some(msg.get_priority_speaker());
-        }
-        if msg.has_recording() {
-            ud.recording = Some(msg.get_recording());
-        }
-        if msg.has_suppress() {
-            ud.suppress = Some(msg.get_suppress());
-        }
-        if msg.has_self_mute() {
-            ud.self_mute = Some(msg.get_self_mute());
-        }
-        if msg.has_self_deaf() {
-            ud.self_deaf = Some(msg.get_self_deaf());
-        }
-        if msg.has_mute() {
-            ud.mute = Some(msg.get_mute());
-        }
-        if msg.has_deaf() {
-            ud.deaf = Some(msg.get_deaf());
-        }
-        if msg.has_channel_id() {
-            ud.channel_id = Some(msg.get_channel_id());
-        }
-        ud
     }
 }


### PR DESCRIPTION
This resolves #30. Since `UserDiff` is an implementation detail of mumd, it should be fine to hide it from consumers of mumd. This also reduces the amount of dependencies of mumlib and consequently mumctl, leading to faster compilation times and smaller binaries.