### PR TITLE
Make use of updated rust-mumble-protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "mumble-protocol"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb966bde3fc52998b9b74522e8aa22826823cc69cbf672893f79115195c76921"
+checksum = "4954adf2418ebc052d723997cf3e090729132d59a795113db931aa5811e46542"
 dependencies = [
  "byteorder",
  "bytes",

--- a/mumd/Cargo.toml
+++ b/mumd/Cargo.toml
@@ -26,7 +26,7 @@ futures-util = "0.3"
 hound = "3.4"
 ipc-channel = "0.14"
 log = "0.4"
-mumble-protocol = "0.3"
+mumble-protocol = "0.3.1"
 native-tls = "0.2"
 openssl = { version = "0.10" }
 opus = "0.2"

--- a/mumd/src/network/udp.rs
+++ b/mumd/src/network/udp.rs
@@ -283,10 +283,7 @@ pub async fn handle_pings(
         while let Ok(read) = receiver.recv(&mut buf).await {
             assert_eq!(read, 24);
 
-            let packet = match PongPacket::try_from(buf.as_slice()) {
-                Ok(v) => v,
-                Err(_) => panic!(),
-            };
+            let packet = PongPacket::try_from(buf.as_slice()).unwrap();
 
             if let Some(handler) = pending.lock().unwrap().remove(&packet.id) {
                 handler(packet);


### PR DESCRIPTION
Resolves #24. I had to force cargo to use version 0.3.1 of rust-mumble-protocol, but I don't know if it's strictly necessary. A version specifier of `"0.3"` might work just fine.