### PR TITLE
Solve pitch bug

### DIFF
--- a/mumd/src/audio.rs
+++ b/mumd/src/audio.rs
@@ -241,6 +241,7 @@ impl Audio {
                 let samples = signal
                     .from_hz_to_hz(interp, spec.sample_rate as f64, SAMPLE_RATE as f64)
                     .until_exhausted()
+                    // if the source audio is stereo and is being played as mono, discard the right audio
                     .flat_map(|e| if output_config.channels == 1 { vec![e[0]] } else { e.to_vec() })
                     .collect::<Vec<f32>>();
                 (*event, samples)


### PR DESCRIPTION
This resolves #27. The issue was that we assumed that the sound output was stereo. Now, we check whether the output is stereo or not when parsing the audio. In the future, we probably want to prefer stereo audio, and fall back to mono if stereo isn't available. Currently, mumd always outputs audio as mono (at least on my machine).