### PR TITLE
Move mumble client stuff away from main

### DIFF
--- a/mumd/src/client.rs
+++ b/mumd/src/client.rs
@@ -26,13 +26,14 @@ pub async fn handle(
     let (response_sender, response_receiver) =
         mpsc::unbounded_channel();
 
-    let state = State::new(packet_sender, connection_info_sender);
+    let state = State::new();
     let state = Arc::new(Mutex::new(state));
     join!(
         tcp::handle(
             Arc::clone(&state),
             connection_info_receiver.clone(),
             crypt_state_sender,
+            packet_sender.clone(),
             packet_receiver,
             response_receiver,
         ),
@@ -46,6 +47,8 @@ pub async fn handle(
             command_receiver,
             response_sender,
             ping_request_sender,
+            packet_sender,
+            connection_info_sender,
         ),
         udp::handle_pings(ping_request_receiver),
     );

--- a/mumd/src/client.rs
+++ b/mumd/src/client.rs
@@ -1,0 +1,52 @@
+use crate::command;
+use crate::network::{tcp, udp, ConnectionInfo};
+use crate::state::State;
+
+use futures_util::join;
+use ipc_channel::ipc::IpcSender;
+use mumble_protocol::{Serverbound, control::ControlPacket, crypt::ClientCryptState};
+use mumlib::command::{Command, CommandResponse};
+use std::sync::{Arc, Mutex};
+use tokio::sync::{mpsc, watch};
+
+pub async fn handle(
+    command_receiver: mpsc::UnboundedReceiver<(
+        Command,
+        IpcSender<mumlib::error::Result<Option<CommandResponse>>>,
+    )>,
+) {
+    let (connection_info_sender, connection_info_receiver) =
+        watch::channel::<Option<ConnectionInfo>>(None);
+    let (crypt_state_sender, crypt_state_receiver) =
+        mpsc::channel::<ClientCryptState>(1);
+    let (packet_sender, packet_receiver) =
+        mpsc::unbounded_channel::<ControlPacket<Serverbound>>();
+    let (ping_request_sender, ping_request_receiver) =
+        mpsc::unbounded_channel();
+    let (response_sender, response_receiver) =
+        mpsc::unbounded_channel();
+
+    let state = State::new(packet_sender, connection_info_sender);
+    let state = Arc::new(Mutex::new(state));
+    join!(
+        tcp::handle(
+            Arc::clone(&state),
+            connection_info_receiver.clone(),
+            crypt_state_sender,
+            packet_receiver,
+            response_receiver,
+        ),
+        udp::handle(
+            Arc::clone(&state),
+            connection_info_receiver.clone(),
+            crypt_state_receiver,
+        ),
+        command::handle(
+            state,
+            command_receiver,
+            response_sender,
+            ping_request_sender,
+        ),
+        udp::handle_pings(ping_request_receiver),
+    );
+}

--- a/mumd/src/main.rs
+++ b/mumd/src/main.rs
@@ -1,23 +1,17 @@
 mod audio;
+mod client;
 mod command;
 mod network;
 mod notify;
 mod state;
 
-use crate::network::ConnectionInfo;
-use crate::state::State;
-
 use futures::join;
 use ipc_channel::ipc::{self, IpcOneShotServer, IpcSender};
 use log::*;
-use mumble_protocol::control::ControlPacket;
-use mumble_protocol::crypt::ClientCryptState;
-use mumble_protocol::voice::Serverbound;
 use mumlib::command::{Command, CommandResponse};
 use mumlib::setup_logger;
 use std::fs;
-use std::sync::{Arc, Mutex};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::mpsc;
 use tokio::task::spawn_blocking;
 
 #[tokio::main]
@@ -45,46 +39,17 @@ async fn main() {
         }
     }
 
-    // Oneshot channel for setting UDP CryptState from control task
-    // For simplicity we don't deal with re-syncing, real applications would have to.
-    let (crypt_state_sender, crypt_state_receiver) = mpsc::channel::<ClientCryptState>(1); // crypt state should always be consumed before sending a new one
-    let (packet_sender, packet_receiver) = mpsc::unbounded_channel::<ControlPacket<Serverbound>>();
     let (command_sender, command_receiver) = mpsc::unbounded_channel::<(
         Command,
         IpcSender<mumlib::error::Result<Option<CommandResponse>>>,
     )>();
-    let (connection_info_sender, connection_info_receiver) =
-        watch::channel::<Option<ConnectionInfo>>(None);
-    let (response_sender, response_receiver) = mpsc::unbounded_channel();
-    let (ping_request_sender, ping_request_receiver) = mpsc::unbounded_channel();
 
-    let state = State::new(packet_sender, connection_info_sender);
-    let state = Arc::new(Mutex::new(state));
-
-    let (_, _, _, e, _) = join!(
-        network::tcp::handle(
-            Arc::clone(&state),
-            connection_info_receiver.clone(),
-            crypt_state_sender,
-            packet_receiver,
-            response_receiver,
-        ),
-        network::udp::handle(
-            Arc::clone(&state),
-            connection_info_receiver.clone(),
-            crypt_state_receiver,
-        ),
-        command::handle(
-            state,
-            command_receiver,
-            response_sender,
-            ping_request_sender,
-        ),
+    let (_, e) = join!(
+        client::handle(command_receiver),
         spawn_blocking(move || {
             // IpcSender is blocking
             receive_oneshot_commands(command_sender);
         }),
-        network::udp::handle_pings(ping_request_receiver),
     );
     e.unwrap();
 }

--- a/mumd/src/state.rs
+++ b/mumd/src/state.rs
@@ -85,7 +85,10 @@ impl State {
         state
     }
 
-    pub fn handle_command(&mut self, command: Command) -> ExecutionContext {
+    pub fn handle_command(
+        &mut self,
+        command: Command,
+    ) -> ExecutionContext {
         match command {
             Command::ChannelJoin { channel_identifier } => {
                 if !matches!(*self.phase_receiver().borrow(), StatePhase::Connected) {

--- a/mumd/src/state.rs
+++ b/mumd/src/state.rs
@@ -57,17 +57,11 @@ pub struct State {
     server: Option<Server>,
     audio: Audio,
 
-    packet_sender: mpsc::UnboundedSender<ControlPacket<Serverbound>>,
-    connection_info_sender: watch::Sender<Option<ConnectionInfo>>,
-
     phase_watcher: (watch::Sender<StatePhase>, watch::Receiver<StatePhase>),
 }
 
 impl State {
-    pub fn new(
-        packet_sender: mpsc::UnboundedSender<ControlPacket<Serverbound>>,
-        connection_info_sender: watch::Sender<Option<ConnectionInfo>>,
-    ) -> Self {
+    pub fn new() -> Self {
         let config = mumlib::config::read_default_cfg();
         let audio = Audio::new(
             config.audio.input_volume.unwrap_or(1.0),
@@ -77,8 +71,6 @@ impl State {
             config,
             server: None,
             audio,
-            packet_sender,
-            connection_info_sender,
             phase_watcher: watch::channel(StatePhase::Disconnected),
         };
         state.reload_config();
@@ -88,6 +80,8 @@ impl State {
     pub fn handle_command(
         &mut self,
         command: Command,
+        packet_sender: &mut mpsc::UnboundedSender<ControlPacket<Serverbound>>,
+        connection_info_sender: &mut watch::Sender<Option<ConnectionInfo>>,
     ) -> ExecutionContext {
         match command {
             Command::ChannelJoin { channel_identifier } => {
@@ -137,7 +131,7 @@ impl State {
                 let mut msg = msgs::UserState::new();
                 msg.set_session(self.server.as_ref().unwrap().session_id().unwrap());
                 msg.set_channel_id(id);
-                self.packet_sender.send(msg.into()).unwrap();
+                packet_sender.send(msg.into()).unwrap();
                 now!(Ok(None))
             }
             Command::ChannelList => {
@@ -203,7 +197,7 @@ impl State {
                     let server = self.server_mut().unwrap();
                     server.set_muted(mute);
                     server.set_deafened(deafen);
-                    self.packet_sender.send(msg.into()).unwrap();
+                    packet_sender.send(msg.into()).unwrap();
                 }
 
                 now!(Ok(new_deaf.map(|b| CommandResponse::DeafenStatus { is_deafened: b })))
@@ -297,7 +291,7 @@ impl State {
                     let server = self.server_mut().unwrap();
                     server.set_muted(mute);
                     server.set_deafened(deafen);
-                    self.packet_sender.send(msg.into()).unwrap();
+                    packet_sender.send(msg.into()).unwrap();
                 }
 
                 now!(Ok(new_mute.map(|b| CommandResponse::MuteStatus { is_muted: b })))
@@ -337,7 +331,7 @@ impl State {
                         return now!(Err(Error::InvalidServerAddrError(host, port)));
                     }
                 };
-                self.connection_info_sender
+                connection_info_sender
                     .send(Some(ConnectionInfo::new(
                         socket_addr,
                         host,
@@ -594,9 +588,6 @@ impl State {
     }
     pub fn audio_mut(&mut self) -> &mut Audio {
         &mut self.audio
-    }
-    pub fn packet_sender(&self) -> mpsc::UnboundedSender<ControlPacket<Serverbound>> {
-        self.packet_sender.clone()
     }
     pub fn phase_receiver(&self) -> watch::Receiver<StatePhase> {
         self.phase_watcher.1.clone()


### PR DESCRIPTION
See #46. This PR does two things

1. Move client implementation away from main. IMO it's clearer if main `join!`s the client with the IPC handler instead of joining TCP/UDP as well. It's also a stepping stone for creating a proper `Client` backend that can be depended on by others.

2) Move some channels away from `State`. IMO `State` should only store actual state.

Lots of opinions here :)